### PR TITLE
Remove invalid runtime override from Vercel config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,7 @@
   "outputDirectory": "dist/spa",
   "regions": ["gru1"],
   "functions": {
-    "api/**": { "maxDuration": 60, "runtime": "nodejs20.x" }
+    "api/**": { "maxDuration": 60 }
   },
   "rewrites": [
     { "source": "/api/(.*)", "destination": "/api/index.ts" },


### PR DESCRIPTION
cgen-bd8eb27df8ec468fa73b514d321a2f22