### PR TITLE
Add Node.js 20.x runtime to Vercel API functions

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,7 @@
   "outputDirectory": "dist/spa",
   "regions": ["gru1"],
   "functions": {
-    "api/**": { "maxDuration": 60, "includeFiles": "dist/server/**" }
+    "api/**": { "runtime": "nodejs20.x", "maxDuration": 60, "includeFiles": "dist/server/**" }
   },
   "rewrites": [
     { "source": "/api/(.*)", "destination": "/api/index.ts" },


### PR DESCRIPTION
## Purpose

The user was experiencing 500 Internal Server Error issues with FUNCTION_INVOCATION_FAILED when accessing admin endpoints on their Vercel-deployed application. The errors were occurring on routes like `/api/admin/users` and `/api/admin/activities`. After successfully configuring Supabase connection and authentication, the remaining issue was related to Vercel function runtime configuration.

## Code changes

- Updated `vercel.json` configuration to explicitly specify Node.js 20.x runtime for API functions
- Added `"runtime": "nodejs20.x"` parameter to the functions configuration
- This ensures compatibility and proper execution of server-side API endpoints on Vercel platform

The change addresses deployment-specific runtime issues that were causing function invocation failures in the production environment.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 32`

🔗 [Edit in Builder.io](https://builder.io/app/projects/08332a972edf4b1fbc2d0abfe006f0d7/spark-zone)

👀 [Preview Link](https://08332a972edf4b1fbc2d0abfe006f0d7-spark-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>08332a972edf4b1fbc2d0abfe006f0d7</projectId>-->
<!--<branchName>spark-zone</branchName>-->