### PR TITLE
Fix Vercel API routing to resolve 404 errors

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -6,7 +6,7 @@
     "api/**": { "maxDuration": 60, "includeFiles": "dist/**" }
   },
   "routes": [
-    { "src": "/api/(.*)", "dest": "/api/$1" },
+    { "src": "/api/(.*)", "dest": "/api" },
     { "src": "/assets/(.*)", "dest": "/assets/$1" },
     { "src": "/favicon.ico", "dest": "/favicon.ico" },
     { "src": "/robots.txt", "dest": "/robots.txt" },


### PR DESCRIPTION
## Purpose

The user was experiencing 404 errors when accessing API endpoints on Vercel (specifically `/api/admin/logins`). They needed help configuring Vercel properly to resolve routing issues and connect to their Supabase database. The main goal was to fix the deployment configuration so that admin panel functions would work correctly.

## Code changes

Updated the Vercel routing configuration in `vercel.json`:
- Modified the API route destination from `/api/$1` to `/api` 
- This change fixes the routing pattern to properly handle API requests and resolve the 404 Not Found errors

The fix ensures that all API requests are correctly routed to the API directory structure, allowing the admin authentication endpoints to function properly on the Vercel deployment.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 65`

🔗 [Edit in Builder.io](https://builder.io/app/projects/1ed00db18bf2438e9fae1c8dd57658c6/orbit-garden)

👀 [Preview Link](https://1ed00db18bf2438e9fae1c8dd57658c6-orbit-garden.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>1ed00db18bf2438e9fae1c8dd57658c6</projectId>-->
<!--<branchName>orbit-garden</branchName>-->