### PR TITLE
Remove serverless-http wrapper to fix timeout issues

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -1,4 +1,3 @@
-import serverless from "serverless-http";
 import path from "path";
 import { fileURLToPath, pathToFileURL } from "url";
 
@@ -32,16 +31,18 @@ async function loadCreateServer(): Promise<() => any> {
       if (mod && typeof mod.createServer === "function") return mod.createServer as any;
     } catch {}
   }
-  throw new Error("Server build not found. Ensure dist/server (Vite server build) is included in the function bundle.");
+  throw new Error(
+    "Server build not found. Ensure dist/server (Vite server build) is included in the function bundle."
+  );
 }
 
-let _handler: any | null = null;
+let app: any | null = null;
 
-export default async function api(req: any, res: any) {
-  if (!_handler) {
+export default async function handler(req: any, res: any) {
+  if (!app) {
     const createServer = await loadCreateServer();
-    const app = createServer();
-    _handler = serverless(app as any);
+    app = createServer();
   }
-  return (_handler as any)(req, res);
+  // Express apps are request handlers (req, res)
+  return (app as any)(req, res);
 }


### PR DESCRIPTION
## Purpose

The user was experiencing Vercel Runtime Timeout Errors when testing the api/ping endpoint, with tasks timing out after 60 seconds. This change aims to resolve the timeout issues by simplifying the serverless function implementation.

## Code changes

- **Removed serverless-http dependency**: Eliminated the `serverless-http` import and wrapper that was previously used to adapt the Express app for serverless environments
- **Simplified handler logic**: Replaced the `_handler` variable with direct `app` usage, removing the serverless wrapper layer
- **Direct Express handling**: Modified the export function to directly use the Express app as a request handler instead of wrapping it with serverless-http
- **Code formatting**: Improved error message formatting for better readability

The changes eliminate an unnecessary abstraction layer that may have been contributing to the timeout issues in the Vercel runtime environment.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 75`

🔗 [Edit in Builder.io](https://builder.io/app/projects/3ab578daa6bb44d1a6f882a128e1c583/pixel-space)

👀 [Preview Link](https://3ab578daa6bb44d1a6f882a128e1c583-pixel-space.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>3ab578daa6bb44d1a6f882a128e1c583</projectId>-->
<!--<branchName>pixel-space</branchName>-->